### PR TITLE
chore: fix indent in `deployment.yaml`

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "rustdesk-server.labels" . | nindent 8 }}
-	{{- with .Values.podLabels }}
+        {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:


### PR DESCRIPTION
tab => 8 whitespaces
